### PR TITLE
Fix value interpolation of date placeholders in callout number

### DIFF
--- a/src/Wooplatnica.php
+++ b/src/Wooplatnica.php
@@ -224,10 +224,10 @@ EOS;
             '%day%',
         ], [
             $order->get_id(),
-            date('Y-m-d'),
-            date('Y'),
-            date('m'),
-            date('d'),
+            date('Y-m-d', $order->get_date_created()->getTimestamp()),
+            date('Y', $order->get_date_created()->getTimestamp()),
+            date('m', $order->get_date_created()->getTimestamp()),
+            date('d', $order->get_date_created()->getTimestamp()),
         ], $string);
     }
 


### PR DESCRIPTION
Currently this plugin has bug that manifests in inconsistency of callout number of payment slip through time.

Let's take the following scenario:
suppose that `%order%-%date%` is being set as callout number pattern. If user ordered something **yesterday** (on 15th October 2019) by selecting paying using payment slip, but decides to perform that payment **today** (on 16th October 2019), then when loading previously generated payment slip from the order history the wrong callout number would be displayed. In other words, callout number would be based on current date (i.e. XXXX-2019-10-16) instead on the date when the order was placed/created (i.e. XXXX-2019-10-15).
The idea should be to use order creation date for setting the callout number value since that way the callout number would be the same, regardless of when the order page page with the payment slip image would be loaded.

Therefore, this pull request contains changes for replacing date placeholders in callout number with date components of order creation date instead of current date