### PR TITLE
Update Wooplatnica.php

### DIFF
--- a/src/Wooplatnica.php
+++ b/src/Wooplatnica.php
@@ -225,7 +225,7 @@ EOS;
             '%month%',
             '%day%',
         ], [
-            $order->get_id(),
+            $order->get_order_number(),
             date('Y-m-d', $order->get_date_created()->getTimestamp()),
             date('Y', $order->get_date_created()->getTimestamp()),
             date('m', $order->get_date_created()->getTimestamp()),


### PR DESCRIPTION
Placeholder %order% should be replaced with order number, not ID 
If one is using custom order numbers, they will have no clue where to look for specific order, so they need order number, not ID. If this number is the same, there will be no changes.