### PR TITLE
Display payment slip for order in order history

### DIFF
--- a/src/Wooplatnica.php
+++ b/src/Wooplatnica.php
@@ -33,6 +33,7 @@ class Wooplatnica
         if ($this->options['enabled'] === 'yes') {
             add_action("woocommerce_thankyou_{$this->domain}", array($this, 'thankyou_page'));
             add_action('woocommerce_email_after_order_table', array($this, 'email_instructions'), 10, 3);
+	    // add to my account page
             add_action( 'woocommerce_view_order', array($this, 'view_order_instructions'), 10, 3);
         }
 

--- a/src/Wooplatnica.php
+++ b/src/Wooplatnica.php
@@ -33,6 +33,7 @@ class Wooplatnica
         if ($this->options['enabled'] === 'yes') {
             add_action("woocommerce_thankyou_{$this->domain}", array($this, 'thankyou_page'));
             add_action('woocommerce_email_after_order_table', array($this, 'email_instructions'), 10, 3);
+            add_action( 'woocommerce_view_order', array($this, 'view_order_instructions'), 10, 3);
         }
 
     }
@@ -149,7 +150,7 @@ class Wooplatnica
             echo base64_encode($payment_slip_blob);
             echo "\" alt=\"$img_element_alt\"/><br/>";
             echo <<< EOS
-            <button type="button" id="download-payment-slip">$download_button_text</button>
+            <button type="button" id="download-payment-slip" style="margin-bottom:10px;">$download_button_text</button>
             <script type="text/javascript">
                 var fileName = '$file_name';
                 const clearUrl = url => url.replace(/^data:image\/\w+?;base64,/, '');
@@ -274,5 +275,20 @@ EOS;
         }
         $order = wc_get_order( $order_id );
         $this->generate_payment_slip(null, $order, false);
+    }
+     /**
+     * Output for the My account -> View order page.
+     */
+    public function view_order_instructions($order_id) {
+		// Get an instance of the WC_Order object
+        $order = wc_get_order( $order_id );
+		
+		if( $order->get_payment_method() === 'wooplatnica-croatia' && $order->has_status('on-hold')){
+			if ($this->options['description']) {
+				echo wpautop(wptexturize(wp_kses_post($this->options['description'])));
+			}
+			$order = wc_get_order( $order_id );
+			$this->generate_payment_slip(null, $order, false);
+		 }
     }
 }

--- a/src/Wooplatnica.php
+++ b/src/Wooplatnica.php
@@ -280,7 +280,7 @@ EOS;
      * Output for the My account -> View order page.
      */
     public function view_order_instructions($order_id) {
-		// Get an instance of the WC_Order object
+	// Get an instance of the WC_Order object
         $order = wc_get_order( $order_id );
 		
 		if( $order->get_payment_method() === 'wooplatnica-croatia' && $order->has_status('on-hold')){


### PR DESCRIPTION
If the user wants to check order and payment details of previously placed order, (s)he could take a look at previously received e-mail message or in order history section of the web-shop. Until now the second option wasn't supported, so commits within this pull request contain changes for accomplishing that.